### PR TITLE
Fix missing CLIENT_IP_HEADER in compose.yaml

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -24,6 +24,7 @@ services:
       - DISABLE_REGISTRATION
       - IP_GEOLOCATION_DB_PATH
       - DEBUG_MODE
+      - CLIENT_IP_HEADER
 
       # Emails configuration (SMTP)
       - SMTP_HOST


### PR DESCRIPTION
## Problem

`CLIENT_IP_HEADER` is documented in the docs and included in `.env.example`, but was missing from `compose.yaml`. Because of this, `swetrix-api` never picked up the variable when running via Docker Compose.

This caused events to be recorded with the wrong IP address in setups where the Swetrix event is not sent directly by the end client — for example, when the backend proxies or originates the event on behalf of the client. Without `CLIENT_IP_HEADER`, the service had no way to extract the real client IP from the request headers and would fall back to the IP of the calling service instead.

## Fix

Added `CLIENT_IP_HEADER` to the environment section of the `swetrix-api` service in `compose.yaml` so it is passed through correctly at runtime.

## Testing

Verified that after the change, `swetrix-api` correctly reads the `CLIENT_IP_HEADER` value and resolves the real client IP rather than the backend's IP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service configuration variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->