### PR TITLE
Update nginx to 1.31.1

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -104,7 +104,7 @@ services:
         hard: 262144
 
   nginx-proxy:
-    image: nginx:1.31.0-alpine
+    image: nginx:1.31.1-alpine
     restart: always
     depends_on:
       swetrix:

--- a/compose.yaml
+++ b/compose.yaml
@@ -104,7 +104,7 @@ services:
         hard: 262144
 
   nginx-proxy:
-    image: nginx:1.29.8-alpine
+    image: nginx:1.31.0-alpine
     restart: always
     depends_on:
       swetrix:


### PR DESCRIPTION
### Description
This PR updates the `nginx-proxy` service image tag in `compose.yaml` from `nginx:1.29.8-alpine` to `nginx:1.31.0-alpine`. 

The current `1.29.x` mainline image stream is vulnerable to **CVE-2026-42945** (NGINX Rift), a critical heap buffer overflow in the NGINX rewrite module that can lead to Denial of Service or potential Remote Code Execution (RCE). 

Bumping the image tag to `1.31.0-alpine` mitigates this supply-chain security risk for all self-hosters utilizing the standard deployment stack.

### Changes
* Updated `nginx-proxy` image from `nginx:1.29.8-alpine` to `nginx:1.31.0-alpine` in `compose.yaml`.

### Testing & Impact
* **Breaking Changes:** None. Core routing syntax, proxy modules, and environment bindings are fully backwards compatible between NGINX 1.29.x and 1.31.x.
* Verified that the container boots cleanly and proxies upstream traffic to the web app and API layers as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded the nginx proxy service to a newer stable release.
  * This update brings up-to-date stability and maintenance improvements for the proxy layer, reducing risk from outdated components and aligning the deployment with recent upstream fixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Swetrix/selfhosting/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->