### PR TITLE
Fix healthcheck IPv6 resolution issue

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -9,7 +9,7 @@ services:
       - BASE_URL=${BASE_URL}
     healthcheck:
       test:
-        ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/ping || exit 1"]
+        ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://127.0.0.1:3000/ping || exit 1"]
       interval: 30s
       start_period: 15s
 
@@ -59,7 +59,7 @@ services:
         condition: service_healthy
     healthcheck:
       test:
-        ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:5005/ping || exit 1"]
+        ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://127.0.0.1:5005/ping || exit 1"]
       interval: 30s
       start_period: 15s
 


### PR DESCRIPTION
## Problem

On some Docker setups (Ubuntu + recent Docker versions), `localhost` resolves to IPv6 `::1` before IPv4. The swetrix-fe and swetrix-api containers bind to IPv4 only (`0.0.0.0`), causing healthchecks using `localhost` to fail with "Connection refused".

This results in the frontend container being marked unhealthy, which blocks nginx-proxy startup due to the `condition: service_healthy` dependency.

## Fix

Use `127.0.0.1` explicitly in healthchecks instead of `localhost`. This avoids the IPv6/IPv4 resolution ambiguity.

## Verification

Tested on Ubuntu 24.04 with Docker 29.6.0 — healthchecks now pass consistently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service health checks so they more reliably detect when the app and API are running.
  * Updated ping health checks to probe via the local IP address to reduce intermittent startup/status detection issues.
  * Refined the reverse proxy setup in the Compose configuration for more consistent port exposure and configuration loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->